### PR TITLE
Fix for Issue #1: Undefined Behavior in with_capacity and Clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ proptest = "1.0"
 proptest-derive = "0.2.0"
 serde = "1.0"
 serde_json = "1.0"
+rand = { version="0.9.2", features=["std"] }
 
 [dependencies.serde]
 version = "1.0"


### PR DESCRIPTION
closes #1 

Fix for `DeVec::with_capacity`: Check for zero and make a dangling pointer, as done previously in `Devec::new`.
Added tests for with_capacity and ran them under Miri to make sure that it does not produce undefined behavior, such as with zero-sized allocations.

Fix for `DeVec::clone`: the implementation incorrectly used the new DeVec's length (always 0 at the start) instead of the old DeVec's length when determining the start location. This resulted in not subtracting the relevant length and going out of bounds.
Added tests for Clone to check for Undefined Behavior, as seen in issue #1.